### PR TITLE
feat: Add compilation in custom location(folder)

### DIFF
--- a/api/src/handlers/compile.rs
+++ b/api/src/handlers/compile.rs
@@ -69,6 +69,14 @@ pub async fn do_compile(compilation_request: CompilationRequest) -> Result<Json<
         return Err(ApiError::VersionNotSupported(zksolc_version));
     }
 
+    if compilation_request.contracts.is_empty() {
+        return Ok(Json(CompileResponse {
+            file_content: vec![],
+            status: status_code_to_message(Some(0)),
+            message: "Nothing to compile".into(),
+        }));
+    }
+
     let namespace = generate_folder_name();
 
     // root directory for the contracts

--- a/api/src/handlers/compile.rs
+++ b/api/src/handlers/compile.rs
@@ -16,8 +16,8 @@ use rocket::serde::json::Json;
 use rocket::{tokio, State};
 use std::path::Path;
 use std::process::{Command, Stdio};
-use tracing::info;
 use tracing::instrument;
+use tracing::{error, info};
 
 #[instrument]
 #[post("/compile", format = "json", data = "<request_json>")]
@@ -98,11 +98,15 @@ pub async fn do_compile(compilation_request: CompilationRequest) -> Result<Json<
     };
 
     // write the hardhat config file
-    let hardhat_config_content = HardhatConfigBuilder::new()
+    let mut hardhat_config_builder = HardhatConfigBuilder::new();
+    hardhat_config_builder
         .zksolc_version(&zksolc_version)
-        .solidity_version(DEFAULT_SOLIDITY_VERSION)
-        .build()
-        .to_string_config();
+        .solidity_version(DEFAULT_SOLIDITY_VERSION);
+    if let Some(target_path) = compilation_request.target_path {
+        hardhat_config_builder.paths_sources(&target_path);
+    }
+
+    let hardhat_config_content = hardhat_config_builder.build().to_string_config();
 
     // create parent directories
     tokio::fs::create_dir_all(hardhat_config_path.parent().unwrap())
@@ -134,6 +138,10 @@ pub async fn do_compile(compilation_request: CompilationRequest) -> Result<Json<
 
     info!("Output: \n{:?}", String::from_utf8_lossy(&output.stdout));
     if !status.success() {
+        error!(
+            "Compilation error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
         return Ok(Json(CompileResponse {
             file_content: vec![],
             message: format!(
@@ -157,9 +165,8 @@ pub async fn do_compile(compilation_request: CompilationRequest) -> Result<Json<
         let relative_path_str = relative_path.to_str().unwrap();
 
         // todo(varex83): is it the best way to check?
-        let is_contract = relative_path_str.starts_with("contracts")
-            && !relative_path_str.ends_with(".dbg.json")
-            && relative_path_str.ends_with(".json");
+        let is_contract =
+            !relative_path_str.ends_with(".dbg.json") && relative_path_str.ends_with(".json");
 
         file_contents.push(CompiledFile {
             file_name: relative_path_str.to_string(),

--- a/api/src/handlers/types.rs
+++ b/api/src/handlers/types.rs
@@ -40,6 +40,7 @@ pub struct CompilationConfig {
 pub struct CompilationRequest {
     pub config: CompilationConfig,
     pub contracts: Vec<CompiledFile>,
+    pub target_path: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -57,6 +58,8 @@ pub struct VerifyConfig {
 pub struct VerificationRequest {
     pub config: VerifyConfig,
     pub contracts: Vec<CompiledFile>,
+    // In format: path/Some.sol:ContractName
+    pub target_contract: Option<String>,
 }
 
 #[derive(Debug)]

--- a/api/src/handlers/verify.rs
+++ b/api/src/handlers/verify.rs
@@ -58,6 +58,7 @@ pub async fn get_verify_result(process_id: String, engine: &State<WorkerEngine>)
         _ => String::from("Result not available"),
     })
 }
+
 fn extract_verify_args(request: &VerificationRequest) -> Vec<String> {
     let mut args: Vec<String> = vec!["hardhat".into(), "verify".into(), "--network".into()];
     if request.config.network == "sepolia" {

--- a/api/src/handlers/verify.rs
+++ b/api/src/handlers/verify.rs
@@ -58,9 +58,27 @@ pub async fn get_verify_result(process_id: String, engine: &State<WorkerEngine>)
         _ => String::from("Result not available"),
     })
 }
+fn extract_verify_args(request: &VerificationRequest) -> Vec<String> {
+    let mut args: Vec<String> = vec!["hardhat".into(), "verify".into(), "--network".into()];
+    if request.config.network == "sepolia" {
+        args.push("zkSyncTestnet".into())
+    } else {
+        args.push("zkSyncMainnet".into())
+    }
+
+    if let Some(ref target_contract) = request.target_contract {
+        args.push("--contract".into());
+        args.push(target_contract.clone());
+    }
+
+    args.push(request.config.contract_address.clone());
+    args.extend(request.config.inputs.clone());
+
+    args
+}
 
 pub async fn do_verify(verification_request: VerificationRequest) -> Result<Json<VerifyResponse>> {
-    let zksolc_version = verification_request.config.zksolc_version;
+    let zksolc_version = verification_request.config.zksolc_version.clone();
 
     // check if the version is supported
     if !ZKSOLC_VERSIONS.contains(&zksolc_version.as_str()) {
@@ -70,9 +88,10 @@ pub async fn do_verify(verification_request: VerificationRequest) -> Result<Json
     let solc_version = verification_request
         .config
         .solc_version
+        .clone()
         .unwrap_or(DEFAULT_SOLIDITY_VERSION.to_string());
 
-    let network = verification_request.config.network;
+    let network = verification_request.config.network.clone();
 
     // check if the network is supported
     if !ALLOWED_NETWORKS.contains(&network.as_str()) {
@@ -126,20 +145,10 @@ pub async fn do_verify(verification_request: VerificationRequest) -> Result<Json
     // initialize the files
     initialize_files(verification_request.contracts.clone(), workspace_path).await?;
 
+    let args = extract_verify_args(&verification_request);
     let command = Command::new("npx")
-        .arg("hardhat")
-        .arg("verify")
+        .args(args)
         .current_dir(workspace_path)
-        .args([
-            "--network",
-            if network == "sepolia" {
-                "zkSyncTestnet"
-            } else {
-                "zkSyncMainnet"
-            },
-        ])
-        .arg(verification_request.config.contract_address)
-        .args(verification_request.config.inputs)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn();

--- a/api/src/utils/lib.rs
+++ b/api/src/utils/lib.rs
@@ -205,6 +205,7 @@ pub fn generate_mock_compile_request() -> CompilationRequest {
             file_content: generate_mock_solidity_file_content(),
             is_contract: false,
         }],
+        target_path: None,
     }
 }
 

--- a/plugin/src/atoms/compilation.ts
+++ b/plugin/src/atoms/compilation.ts
@@ -1,9 +1,11 @@
 import { atom } from 'jotai'
 
+export type CompilationType = 'PROJECT' | 'SINGLE_FILE' | 'NONE'
 const compileStatusAtom = atom<string>('Compiling....')
 const hashDirAtom = atom<string>('')
 const isCompilingAtom = atom<boolean>(false)
-type CompilationKeys = 'status' | 'isCompiling' | 'hashDir' | 'errorMessages'
+const compilationTypeAtom = atom<CompilationType>('NONE')
+type CompilationKeys = 'status' | 'isCompiling' | 'hashDir' | 'errorMessages' | 'compilationType'
 const compileErrorMessagesAtom = atom<string[]>([])
 
 interface SetCompilationValue {
@@ -17,7 +19,8 @@ const compilationAtom = atom(
       status: get(compileStatusAtom),
       isCompiling: get(isCompilingAtom),
       hashDir: get(hashDirAtom),
-      errorMessages: get(compileErrorMessagesAtom)
+      errorMessages: get(compileErrorMessagesAtom),
+      compilationType: get(compilationTypeAtom)
     }
   },
   (_get, set, newValue: SetCompilationValue) => {
@@ -34,6 +37,9 @@ const compilationAtom = atom(
       case 'errorMessages':
         Array.isArray(newValue?.value) && set(compileErrorMessagesAtom, newValue?.value)
         break
+      case 'compilationType':
+        typeof newValue?.value === 'string' && set(compilationTypeAtom, newValue?.value as CompilationType)
+        break
     }
   }
 )
@@ -44,6 +50,7 @@ export {
   hashDirAtom,
   compilationAtom,
   compileErrorMessagesAtom,
+  compilationTypeAtom,
   type SetCompilationValue,
   type CompilationKeys
 }

--- a/plugin/src/atoms/deployment.ts
+++ b/plugin/src/atoms/deployment.ts
@@ -1,15 +1,15 @@
 import { atom } from 'jotai'
 import { type Input } from '../types/contracts'
 
-const isDeployingAtom = atom<boolean>(false)
+type DeploymentStatus = 'IDLE' | 'IN_PROGRESS' | 'ERROR' | 'DONE'
 
-const deployStatusAtom = atom<string>('')
+const deployStatusAtom = atom<DeploymentStatus>('IDLE')
 
 const constructorInputsAtom = atom<Input[]>([])
 
 const notEnoughInputsAtom = atom<boolean>(false)
 
-type Key = 'isDeploying' | 'deployStatus' | 'constructorInputs' | 'notEnoughInputs'
+type Key = 'deployStatus' | 'constructorInputs' | 'notEnoughInputs'
 
 interface SetDeploymentAtom {
   key: Key
@@ -19,7 +19,6 @@ interface SetDeploymentAtom {
 const deploymentAtom = atom(
   (get) => {
     return {
-      isDeploying: get(isDeployingAtom),
       deployStatus: get(deployStatusAtom),
       constructorInputs: get(constructorInputsAtom),
       notEnoughInputs: get(notEnoughInputsAtom)
@@ -27,11 +26,8 @@ const deploymentAtom = atom(
   },
   (_get, set, newValue: SetDeploymentAtom) => {
     switch (newValue?.key) {
-      case 'isDeploying':
-        typeof newValue?.value === 'boolean' && set(isDeployingAtom, newValue?.value)
-        break
       case 'deployStatus':
-        typeof newValue?.value === 'string' && set(deployStatusAtom, newValue?.value)
+        typeof newValue?.value === 'string' && set(deployStatusAtom, newValue?.value as DeploymentStatus)
         break
       case 'constructorInputs':
         Array.isArray(newValue?.value) && set(constructorInputsAtom, newValue?.value)
@@ -43,4 +39,4 @@ const deploymentAtom = atom(
   }
 )
 
-export { isDeployingAtom, deployStatusAtom, constructorInputsAtom, notEnoughInputsAtom, deploymentAtom }
+export { deployStatusAtom, constructorInputsAtom, notEnoughInputsAtom, deploymentAtom }

--- a/plugin/src/atoms/index.ts
+++ b/plugin/src/atoms/index.ts
@@ -5,18 +5,14 @@ export {
   isCompilingAtom,
   compileErrorMessagesAtom,
   type CompilationKeys,
-  type SetCompilationValue
+  type SetCompilationValue,
+  compilationTypeAtom,
+  type CompilationType
 } from './compilation'
 export { contractsAtom, selectedContractAtom } from './compiledContracts'
 export { accountAtom, providerAtom } from './connection'
 export { deployedContractsAtom, deployedSelectedContractAtom } from './deployedContracts'
-export {
-  constructorInputsAtom,
-  deployStatusAtom,
-  deploymentAtom,
-  isDeployingAtom,
-  notEnoughInputsAtom
-} from './deployment'
+export { constructorInputsAtom, deployStatusAtom, deploymentAtom, notEnoughInputsAtom } from './deployment'
 export {
   availableDevnetAccountsAtom,
   devnetAtom,

--- a/plugin/src/features/Plugin/index.tsx
+++ b/plugin/src/features/Plugin/index.tsx
@@ -46,7 +46,7 @@ export const Plugin = () => {
   }, [setHashDir])
 
   // Deployment Context state variables
-  const { isDeploying, deployStatus } = useAtomValue(deploymentAtom)
+  const { deployStatus } = useAtomValue(deploymentAtom)
 
   // Interaction state variables
   const [interactionStatus] = useState<'loading' | 'success' | 'error' | ''>('')
@@ -100,15 +100,7 @@ export const Plugin = () => {
                   <span className="d-flex align-items-center" style={{ gap: '0.5rem' }}>
                     <p style={{ all: 'unset' }}>Deploy</p>
                     <StateAction
-                      value={
-                        isDeploying
-                          ? 'loading'
-                          : deployStatus === 'error'
-                            ? 'error'
-                            : deployStatus === 'done'
-                              ? 'success'
-                              : ''
-                      }
+                      value={deployStatus === 'ERROR' ? 'error' : deployStatus === 'DONE' ? 'success' : ''}
                     />
                   </span>
                 </AccordionTrigger>

--- a/plugin/src/hooks/useCompileHelpers.ts
+++ b/plugin/src/hooks/useCompileHelpers.ts
@@ -1,0 +1,141 @@
+import {
+  CompilationType,
+  compileErrorMessagesAtom,
+  contractsAtom,
+  selectedContractAtom,
+  solidityVersionAtom
+} from '@/atoms'
+import { currentFilenameAtom, currentWorkspacePathAtom, remixClientAtom } from '@/stores/remixClient'
+import { CompilationResult, Contract } from '@/types/contracts'
+import { artifactFolder } from '@/utils/utils'
+import { useAtomValue, useSetAtom } from 'jotai'
+
+export const useCompileHelpers = () => {
+  const remixClient = useAtomValue(remixClientAtom)
+  const setCompileErrorMessages = useSetAtom(compileErrorMessagesAtom)
+  const currentWorkspacePath = useAtomValue(currentWorkspacePathAtom)
+  const solidityVersion = useAtomValue(solidityVersionAtom)
+  const currentFilename = useAtomValue(currentFilenameAtom)
+  const setContracts = useSetAtom(contractsAtom)
+  const setSelectedContract = useSetAtom(selectedContractAtom)
+
+  const getDefaultWorkspaceContents: any = () => ({
+    config: {
+      version: solidityVersion,
+      user_libraries: []
+    },
+    contracts: [] as Array<{ file_name: string; file_content: string; is_contract: boolean }>
+  })
+
+  const emitErrorToRemix = async (compileResult: CompilationResult) => {
+    await remixClient.terminal.log({
+      value: compileResult.message,
+      type: 'error'
+    })
+
+    const errorLets = compileResult.message.trim().split('\n')
+    // remove last element if it's starts with `Error:`
+    if (errorLets[errorLets.length - 1].startsWith('Error:')) {
+      errorLets.pop()
+    }
+
+    // break the errorLets in array of arrays with first element contains the string `Plugin diagnostic`
+    const errorLetsArray = errorLets.reduce(
+      (acc: any, curr: any) => {
+        if (curr.startsWith('error:') || curr.startsWith('warning:')) {
+          acc.push([curr])
+        } else {
+          acc[acc.length - 1].push(curr)
+        }
+        return acc
+      },
+      [['errors diagnostic:']]
+    )
+    // remove the first array
+    errorLetsArray.shift()
+
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    errorLetsArray.forEach(async (errorLet: any) => {
+      const errorType = errorLet[0].split(':')[0].trim()
+      const errorTitle = errorLet[0].split(':').slice(1).join(':').trim()
+      const errorLine = errorLet[1].split(':')[1].trim()
+      const errorColumn = errorLet[1].split(':')[2].trim()
+      // join the rest of the array
+      const errorMsg = errorLet.slice(2).join('\n')
+
+      await remixClient.editor.addAnnotation({
+        row: Number(errorLine) - 1,
+        column: Number(errorColumn) - 1,
+        text: errorMsg + '\n' + errorTitle,
+        type: errorType
+      })
+    })
+    const lastLine = compileResult.message.trim().split('\n').pop()?.trim()
+
+    remixClient.emit('statusChanged', {
+      key: 'failed',
+      type: 'error',
+      title: (lastLine ?? '').startsWith('Error') ? lastLine : 'Compilation Failed'
+    })
+    setCompileErrorMessages(errorLets)
+    throw new Error('Solidity Compilation Failed, logs can be read in the terminal log')
+  }
+
+  const writeResultsToArtifacts = async (compileResult: CompilationResult) => {
+    const artifacts: string[] = []
+    for (const file of compileResult.file_content) {
+      const artifactsPath = `${artifactFolder(currentWorkspacePath)}/${file.file_name}`
+      artifacts.push(artifactsPath)
+      try {
+        await remixClient.call('fileManager', 'writeFile', artifactsPath, file.file_content)
+      } catch (e) {
+        if (e instanceof Error) {
+          await remixClient.call(
+            'notification' as any,
+            'toast',
+            e.message + ' try deleting the files: ' + artifactsPath
+          )
+        }
+        remixClient.emit('statusChanged', {
+          key: 'succeed',
+          type: 'warning',
+          title: 'Failed to save artifacts'
+        })
+      } finally {
+        remixClient.emit('statusChanged', {
+          key: 'succeed',
+          type: 'info',
+          title: 'Saved artifacts'
+        })
+      }
+    }
+  }
+
+  const setCompiledContracts = (compileResult: CompilationResult, compilationType: CompilationType) => {
+    const contractsToAdd: Contract[] = []
+    if (compilationType === 'PROJECT') {
+      for (const file of compileResult.file_content) {
+        if (!file.is_contract || !file.file_name.startsWith('contracts/')) continue
+
+        const contract = JSON.parse(file.file_content) as Contract
+        contractsToAdd.push(contract)
+      }
+    } else {
+      for (const file of compileResult.file_content) {
+        if (!file.is_contract || !file.file_name.includes(currentFilename)) continue
+
+        const contract = JSON.parse(file.file_content) as Contract
+        contractsToAdd.push(contract)
+      }
+    }
+    setContracts(contractsToAdd)
+    setSelectedContract(contractsToAdd[0])
+  }
+
+  return {
+    emitErrorToRemix,
+    writeResultsToArtifacts,
+    getDefaultWorkspaceContents,
+    setCompiledContracts
+  }
+}

--- a/plugin/src/stores/remixClient.ts
+++ b/plugin/src/stores/remixClient.ts
@@ -8,7 +8,12 @@ const WORKSPACE_ROOT = '.workspaces'
 const remixClientAtom = atom({} as unknown as RemixClient)
 const noFileSelectedAtom = atom(false)
 const isValidSolidityAtom = atom(false)
-const currentFilenameAtom = atom('')
+const currentFilepathAtom = atom('')
+const currentFilenameAtom = atom((get) => {
+  const currentFilePath = get(currentFilepathAtom)
+  return getFileNameFromPath(currentFilePath)
+})
+
 const currentWorkspacePathAtom = atom('')
 const isLoadedAtom = atom(false)
 
@@ -43,7 +48,7 @@ async function initializeRemixClient(): Promise<RemixClient> {
     const currentFileExtension = getFileExtension(filename)
     const isValidSolidity = currentFileExtension === 'sol'
     remixClientStore.set(isValidSolidityAtom, isValidSolidity)
-    remixClientStore.set(currentFilenameAtom, filename)
+    remixClientStore.set(currentFilepathAtom, currentFileChanged)
     remixClientStore.set(noFileSelectedAtom, false)
 
     await handleStatusChange()
@@ -51,7 +56,7 @@ async function initializeRemixClient(): Promise<RemixClient> {
 
   remixClient.on('fileManager', 'noFileSelected', async () => {
     remixClientStore.set(noFileSelectedAtom, true)
-    remixClientStore.set(currentFilenameAtom, '')
+    remixClientStore.set(currentFilepathAtom, '')
     remixClientStore.set(isValidSolidityAtom, false)
 
     await handleStatusChange()
@@ -59,7 +64,7 @@ async function initializeRemixClient(): Promise<RemixClient> {
 
   remixClient.on('filePanel', 'workspaceCreated', async (workspace) => {
     remixClientStore.set(noFileSelectedAtom, true)
-    remixClientStore.set(currentFilenameAtom, '')
+    remixClientStore.set(currentFilepathAtom, '')
     remixClientStore.set(isValidSolidityAtom, false)
     remixClientStore.set(currentWorkspacePathAtom, `${WORKSPACE_ROOT}/${workspace as string}`)
   })
@@ -68,7 +73,7 @@ async function initializeRemixClient(): Promise<RemixClient> {
     const workspace = valueRaw as Workspace
 
     remixClientStore.set(noFileSelectedAtom, true)
-    remixClientStore.set(currentFilenameAtom, '')
+    remixClientStore.set(currentFilepathAtom, '')
     remixClientStore.set(isValidSolidityAtom, false)
     remixClientStore.set(currentWorkspacePathAtom, `${WORKSPACE_ROOT}/${workspace.name}`)
   })
@@ -86,5 +91,6 @@ export {
   isValidSolidityAtom,
   currentFilenameAtom,
   currentWorkspacePathAtom,
-  isLoadedAtom
+  isLoadedAtom,
+  currentFilepathAtom
 }

--- a/plugin/src/utils/constants.ts
+++ b/plugin/src/utils/constants.ts
@@ -47,6 +47,8 @@ const licenses = [
   'Business Source License (BSL 1.1)'
 ]
 
+export const FILES_NOT_IN_CONTRACTS_MESSAGE =
+  'Warning: Only files within the /contracts/* folder structure are included in the project compilation. The following smart contracts defined outside this structure will not be available for deployment:'
 export { devnetUrl, networks, networkExplorerUrls, licenses }
 
 export type { Network }

--- a/plugin/src/utils/remix_storage.ts
+++ b/plugin/src/utils/remix_storage.ts
@@ -19,3 +19,25 @@ export const getAllContractFiles = async (remixClient: RemixClient, path: string
   }
   return files
 }
+
+export const getContractTargetPath = (allContracts: ContractFile[], contractFilePath: string) => {
+  for (const { file_name } of allContracts) {
+    if (file_name.includes(contractFilePath)) {
+      const parts = file_name.split('/')
+      if (parts.length === 1) {
+        return './'
+      } else {
+        parts.pop()
+        return './' + parts.join('/')
+      }
+    }
+  }
+
+  return './'
+}
+
+export const findFilesNotInContracts = (allContracts: ContractFile[]) => {
+  return allContracts
+    .filter(({ file_name, is_contract }) => is_contract && !file_name.startsWith('contracts/'))
+    .map(({ file_name }) => file_name.split('/').pop())
+}


### PR DESCRIPTION
@satyambnsal [Notice](https://github.com/NethermindEth/zksync-remix-plugin/blob/2ff673e4e712a38654b0cc4c1357818795bf89a2/api/src/handlers/compile.rs#L168) that the decision of if we shall display contracts from non-standard location shall be taken on Front level. Here I list all of the .sol contracts even outside `/contracts` folder

```python
if !single_file:
    display only from ./contracts
else: 
    display all artifacts
```