### PR TITLE
Support generic array in constructor input

### DIFF
--- a/plugin/src/components/ConstructorInput/index.tsx
+++ b/plugin/src/components/ConstructorInput/index.tsx
@@ -7,10 +7,15 @@ import InputField from '../InputField'
 import { useAtomValue } from 'jotai'
 import { selectedContractAtom } from '../../atoms/compiledContracts'
 
+export type ContractInputType = {
+  internalType: string
+  value: string
+}[]
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface ConstructorContractsProps {
-  inputs: string[]
-  setInputs: (input: string[]) => void
+  inputs: ContractInputType
+  setInputs: (input: ContractInputType) => void
 }
 
 const ConstructorInput: React.FC<ConstructorContractsProps> = ({ inputs, setInputs }: ConstructorContractsProps) => {
@@ -33,10 +38,13 @@ const ConstructorInput: React.FC<ConstructorContractsProps> = ({ inputs, setInpu
           <InputField
             name={generateInputName(input)}
             index={index}
-            value={inputs[index]}
+            value={inputs[index].value}
             onChange={(index, newValue) => {
               const newInputs = [...inputs]
-              newInputs[index] = newValue
+              newInputs[index] = {
+                internalType: input.internalType || 'string',
+                value: newValue
+              }
               setInputs(newInputs)
             }}
             key={index}

--- a/plugin/src/components/FunctionalInput/index.tsx
+++ b/plugin/src/components/FunctionalInput/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react'
 import * as zksync from 'zksync-ethers'
-import { generateInputName } from '../../utils/utils'
+import { generateInputName, parseContractInputs } from '../../utils/utils'
 import { type AbiElement, type Input } from '../../types/contracts'
 import InputField from '../InputField'
 import { ethers } from 'ethers'
@@ -14,6 +14,7 @@ import { accountAtom, providerAtom } from '../../atoms/connection'
 import { useWalletClient } from 'wagmi'
 import { envAtom } from '../../atoms/environment'
 import { remixClientAtom } from '../../stores/remixClient'
+import { ContractInputType } from '../ConstructorInput'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface CompiledContractsProps {
@@ -31,7 +32,7 @@ const MethodInput: React.FC<CompiledContractsProps> = ({ element }: CompiledCont
   const env = useAtomValue(envAtom)
   const provider = useAtomValue(providerAtom)
 
-  const [inputs, setInputs] = useState<string[]>([])
+  const [inputs, setInputs] = useState<ContractInputType>([])
   const [value, setValue] = useState<string>('')
 
   const callContract = async (): Promise<void> => {
@@ -57,7 +58,7 @@ const MethodInput: React.FC<CompiledContractsProps> = ({ element }: CompiledCont
         title: `Executing "${element.name}" method!`
       })
 
-      const callParameters = [...inputs]
+      const callParameters = parseContractInputs(inputs)
       if (element.stateMutability === 'payable') {
         const options: any = { value: ethers.utils.parseEther(value) }
         callParameters.push(options)
@@ -119,7 +120,7 @@ const MethodInput: React.FC<CompiledContractsProps> = ({ element }: CompiledCont
   }
 
   useEffect(() => {
-    setInputs(new Array(element.inputs.length).fill(''))
+    setInputs(new Array(element.inputs.length).fill({ internalType: 'string', value: '' }))
   }, [element])
 
   return (
@@ -153,10 +154,13 @@ const MethodInput: React.FC<CompiledContractsProps> = ({ element }: CompiledCont
           key={index}
           placeholder={generateInputName(input)}
           index={index}
-          value={inputs[index]}
+          value={inputs[index].value}
           onChange={(index, newValue) => {
             const newInputs = [...inputs]
-            newInputs[index] = newValue
+            newInputs[index] = {
+              internalType: input.internalType || 'string',
+              value: newValue
+            }
             setInputs(newInputs)
           }}
         />

--- a/plugin/src/components/FunctionalInput/index.tsx
+++ b/plugin/src/components/FunctionalInput/index.tsx
@@ -32,7 +32,9 @@ const MethodInput: React.FC<CompiledContractsProps> = ({ element }: CompiledCont
   const env = useAtomValue(envAtom)
   const provider = useAtomValue(providerAtom)
 
-  const [inputs, setInputs] = useState<ContractInputType>([])
+  const [inputs, setInputs] = useState<ContractInputType>(
+    new Array(element.inputs.length).fill({ internalType: 'string', value: '' })
+  )
   const [value, setValue] = useState<string>('')
 
   const callContract = async (): Promise<void> => {
@@ -154,7 +156,7 @@ const MethodInput: React.FC<CompiledContractsProps> = ({ element }: CompiledCont
           key={index}
           placeholder={generateInputName(input)}
           index={index}
-          value={inputs[index].value}
+          value={inputs[index]?.value}
           onChange={(index, newValue) => {
             const newInputs = [...inputs]
             newInputs[index] = {

--- a/plugin/src/components/FunctionalInput/index.tsx
+++ b/plugin/src/components/FunctionalInput/index.tsx
@@ -156,7 +156,7 @@ const MethodInput: React.FC<CompiledContractsProps> = ({ element }: CompiledCont
           key={index}
           placeholder={generateInputName(input)}
           index={index}
-          value={inputs[index]?.value}
+          value={inputs[index].value}
           onChange={(index, newValue) => {
             const newInputs = [...inputs]
             newInputs[index] = {


### PR DESCRIPTION
Relevant issue: #41 

**Changes Summary**
Support Generic array as input in contract methods and constructor call.
