### PR TITLE
Consider serivice healthy on response

### DIFF
--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -31,7 +31,7 @@ lazy_static! {
 pub async fn health(engine: &State<WorkerEngine>) -> HealthCheckResponse {
     info!("/health");
 
-    let result = do_compile(generate_mock_compile_request(), &engine.metrics).await;
+    let result = do_compile(generate_mock_compile_request(), &engine.metrics, true).await;
 
     if result.is_ok() {
         HealthCheckResponse::ok()
@@ -59,7 +59,7 @@ pub async fn dispatch_command(
             Err(e) => Err(e),
         },
         ApiCommand::Compile(request) => {
-            let res = match do_compile(request, metrics).await {
+            let res = match do_compile(request, metrics, false).await {
                 Ok(compile_response) => {
                     Ok(ApiCommandResult::Compile(compile_response.into_inner()))
                 }


### PR DESCRIPTION
`do_compile` - considered an excessive step for system health check. That should be do_version_check with simple npc hardhat --version cmd, but reckoned as unnecessary and successful response from service testifies for its health